### PR TITLE
Allow FastImageView component to be the target of the forwardRef, so …

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,8 +45,9 @@ function FastImageBase({
     }
 
     return (
-        <View style={[styles.imageContainer, style]} ref={forwardedRef}>
+        <View style={[styles.imageContainer, style]}>
             <FastImageView
+                ref={forwardedRef}
                 {...props}
                 tintColor={tintColor}
                 style={StyleSheet.absoluteFill}


### PR DESCRIPTION
…FastImage component can be join by ref in users code